### PR TITLE
Update RAMP library using latest release

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
         <link rel="stylesheet" href="<%= BASE_URL %>draw.css" />
         <script src="<%= BASE_URL %>draw.js"></script>
 
-        <link rel="stylesheet" href="<%= BASE_URL %>styles/ramp.css" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ramp-pcar/dist/esDynamic/ramp.css" />
 
         <script
             type="text/javascript"
@@ -41,9 +41,9 @@
             type="text/javascript"
             src="<%= BASE_URL %>js/rv-main.js"
         ></script>
-        <script
-            type="text/javascript"
-            src="<%= BASE_URL %>js/ramp.js"
-        ></script>
+        <script type="module">
+            import * as R4 from 'https://cdn.jsdelivr.net/npm/ramp-pcar/dist/esDynamic/ramp.js';
+            window.RAMP4 = R4;
+        </script>
     </body>
 </html>


### PR DESCRIPTION
For #86 

### Description
This PR updates the RAMP 4 version using the "Easy way" method mentioned in the issue (currently using v4.9.0). Note the RAMP4 maps will not load due to v4.9.0 going over the cdn limit. This PR should be tested and merged once v4.10.0 is released

Will look into the script way mentioned in the issue as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp-pcar/87)
<!-- Reviewable:end -->
